### PR TITLE
Added Config Option for Ignore Rain

### DIFF
--- a/src/main/java/cech12/unlitcampfire/config/ServerConfig.java
+++ b/src/main/java/cech12/unlitcampfire/config/ServerConfig.java
@@ -39,6 +39,8 @@ public class ServerConfig {
     public static final ForgeConfigSpec.IntValue SOUL_CAMPFIRE_MAX_LIT_TIME_EXTENSION;
     public static final ForgeConfigSpec.BooleanValue SOUL_CAMPFIRE_AFFECTED_BY_SLEEP_TIME;
     public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IS_LIT_INFINITELY;
+    public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IS_LIT_INFINITELY;
+    public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IGNORES_RAIN;
 
     static {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -85,6 +87,10 @@ public class ServerConfig {
         GENERATED_CAMPFIRE_IS_LIT_INFINITELY = builder
                 .comment("Whether generated campfires should be lit infinitely.")
                 .define("generatedCampfireIsLitInfinitely", true);
+        
+        GENERATED_CAMPFIRE_IGNORES_RAIN = builder
+                .comment("Whether generated campfires should stay lit in rain.")
+                .define("generatedCampfireIgnoresRain", true);
 
         //soul campfire
         SOUL_CAMPFIRE_LIT_TIME = builder
@@ -126,6 +132,10 @@ public class ServerConfig {
         GENERATED_SOUL_CAMPFIRE_IS_LIT_INFINITELY = builder
                 .comment("Whether generated soul campfires should be lit infinitely.")
                 .define("generatedSoulCampfireIsLitInfinitely", true);
+
+        GENERATED_SOUL_CAMPFIRE_IGNORES_RAIN = builder
+                .comment("Whether generated soul campfires should stay lit in rain.")
+                .define("generatedSoulCampfireIgnoresRain", true);
 
         builder.pop();
 

--- a/src/main/java/cech12/unlitcampfire/config/ServerConfig.java
+++ b/src/main/java/cech12/unlitcampfire/config/ServerConfig.java
@@ -28,6 +28,7 @@ public class ServerConfig {
     public static final ForgeConfigSpec.IntValue CAMPFIRE_MAX_LIT_TIME_EXTENSION;
     public static final ForgeConfigSpec.BooleanValue CAMPFIRE_AFFECTED_BY_SLEEP_TIME;
     public static final ForgeConfigSpec.BooleanValue GENERATED_CAMPFIRE_IS_LIT_INFINITELY;
+    public static final ForgeConfigSpec.BooleanValue INFINITE_CAMPFIRE_IGNORES_RAIN;
 
     public static final ForgeConfigSpec.IntValue SOUL_CAMPFIRE_LIT_TIME;
     public static final ForgeConfigSpec.IntValue SOUL_CAMPFIRE_RUN_OUT_INDICATOR_TIME;
@@ -39,8 +40,7 @@ public class ServerConfig {
     public static final ForgeConfigSpec.IntValue SOUL_CAMPFIRE_MAX_LIT_TIME_EXTENSION;
     public static final ForgeConfigSpec.BooleanValue SOUL_CAMPFIRE_AFFECTED_BY_SLEEP_TIME;
     public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IS_LIT_INFINITELY;
-    public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IS_LIT_INFINITELY;
-    public static final ForgeConfigSpec.BooleanValue GENERATED_SOUL_CAMPFIRE_IGNORES_RAIN;
+    public static final ForgeConfigSpec.BooleanValue INFINITE_SOUL_CAMPFIRE_IGNORES_RAIN;
 
     static {
         final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -88,9 +88,9 @@ public class ServerConfig {
                 .comment("Whether generated campfires should be lit infinitely.")
                 .define("generatedCampfireIsLitInfinitely", true);
         
-        GENERATED_CAMPFIRE_IGNORES_RAIN = builder
-                .comment("Whether generated campfires should stay lit in rain.")
-                .define("generatedCampfireIgnoresRain", true);
+        INFINITE_CAMPFIRE_IGNORES_RAIN = builder
+                .comment("Whether infinite campfires should stay lit in rain.")
+                .define("infiniteCampfireIgnoresRain", true);
 
         //soul campfire
         SOUL_CAMPFIRE_LIT_TIME = builder
@@ -133,9 +133,9 @@ public class ServerConfig {
                 .comment("Whether generated soul campfires should be lit infinitely.")
                 .define("generatedSoulCampfireIsLitInfinitely", true);
 
-        GENERATED_SOUL_CAMPFIRE_IGNORES_RAIN = builder
-                .comment("Whether generated soul campfires should stay lit in rain.")
-                .define("generatedSoulCampfireIgnoresRain", true);
+        INFINITE_SOUL_CAMPFIRE_IGNORES_RAIN = builder
+                .comment("Whether infinite soul campfires should stay lit in rain.")
+                .define("infiniteSoulCampfireIgnoresRain", true);
 
         builder.pop();
 

--- a/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockEntityMixin.java
+++ b/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockEntityMixin.java
@@ -196,18 +196,14 @@ public abstract class CampfireBlockEntityMixin extends BlockEntity implements IC
             }
             //if rain should unlit a campfire, and it is raining there
             int rainUnlitTime = mixinEntity.getRainUnlitTime();
-            boolean isGeneratedCampfire = state.getValue(ICampfireBlockMixin.INFINITE); // Whether campfire block has been generated
-
-            if (rainUnlitTime >= 0 && level.isRainingAt(pos.above())) {
-                // If the campfire isn't generated and isn't set to ignore rain, rain time increments, eventually extinguishing it
-                if (!isGeneratedCampfire || !ServerConfig.GENERATED_CAMPFIRE_IGNORES_RAIN.get()) {
-                    mixinEntity.rainTime++;
-                    if (mixinEntity.rainTime >= rainUnlitTime) {
-                        mixinEntity.unlitCampfire();
-                    }
-                } else {
-                    mixinEntity.rainTime = 0;
+            boolean shouldUnlitByRain = rainUnlitTime >= 0 && (!mixinEntity.burnsInfinite() || !ServerConfig.INFINITE_CAMPFIRE_IGNORES_RAIN.get());
+            if (shouldUnlitByRain && level.isRainingAt(pos.above())) {
+                mixinEntity.rainTime++;
+                if (mixinEntity.rainTime >= rainUnlitTime) {
+                    mixinEntity.unlitCampfire();
                 }
+            } else {
+                mixinEntity.rainTime = 0;
             }
         }
     }

--- a/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockEntityMixin.java
+++ b/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockEntityMixin.java
@@ -196,13 +196,18 @@ public abstract class CampfireBlockEntityMixin extends BlockEntity implements IC
             }
             //if rain should unlit a campfire, and it is raining there
             int rainUnlitTime = mixinEntity.getRainUnlitTime();
+            boolean isGeneratedCampfire = state.getValue(ICampfireBlockMixin.INFINITE); // Whether campfire block has been generated
+
             if (rainUnlitTime >= 0 && level.isRainingAt(pos.above())) {
-                mixinEntity.rainTime++;
-                if (mixinEntity.rainTime >= rainUnlitTime) {
-                    mixinEntity.unlitCampfire();
+                // If the campfire isn't generated and isn't set to ignore rain, rain time increments, eventually extinguishing it
+                if (!isGeneratedCampfire || !ServerConfig.GENERATED_CAMPFIRE_IGNORES_RAIN.get()) {
+                    mixinEntity.rainTime++;
+                    if (mixinEntity.rainTime >= rainUnlitTime) {
+                        mixinEntity.unlitCampfire();
+                    }
+                } else {
+                    mixinEntity.rainTime = 0;
                 }
-            } else {
-                mixinEntity.rainTime = 0;
             }
         }
     }

--- a/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
+++ b/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
@@ -81,7 +81,7 @@ public abstract class CampfireBlockMixin extends BaseEntityBlock implements ICam
         if (cir.getReturnValue() != null) {
             cir.setReturnValue(cir.getReturnValue()
                     .setValue(CampfireBlock.LIT, false)
-                    .setValue(ICampfireBlockMixin.INFINITE, context.getPlayer() == null) //TODO is that an issue?
+                    .setValue(ICampfireBlockMixin.INFINITE, false)
                     .setValue(ICampfireBlockMixin.RUNS_OUT, false)
             );
             cir.cancel();

--- a/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
+++ b/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
@@ -78,17 +78,14 @@ public abstract class CampfireBlockMixin extends BaseEntityBlock implements ICam
 
     @Inject(at = @At("RETURN"), method = "getStateForPlacement", cancellable = true)
     protected void getStateForPlacementProxy(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-    if (cir.getReturnValue() != null) {
-
-        BlockState state = cir.getReturnValue();
-        boolean isGenerated = context.getPlayer() == null; // If there's no player, it's generated
-        // Gets state of campfire block, checking to see if it is generated or placed by the player
-        state = state.setValue(CampfireBlock.LIT, false)
-                    .setValue(ICampfireBlockMixin.INFINITE, isGenerated)
-                    .setValue(ICampfireBlockMixin.RUNS_OUT, false);
-        cir.setReturnValue(state);
-        cir.cancel();
-    }
+        if (cir.getReturnValue() != null) {
+            cir.setReturnValue(cir.getReturnValue()
+                    .setValue(CampfireBlock.LIT, false)
+                    .setValue(ICampfireBlockMixin.INFINITE, context.getPlayer() == null) //TODO is that an issue?
+                    .setValue(ICampfireBlockMixin.RUNS_OUT, false)
+            );
+            cir.cancel();
+        }
     }
 
     @Inject(at = @At("RETURN"), method = "use", cancellable = true)

--- a/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
+++ b/src/main/java/cech12/unlitcampfire/mixin/CampfireBlockMixin.java
@@ -78,12 +78,17 @@ public abstract class CampfireBlockMixin extends BaseEntityBlock implements ICam
 
     @Inject(at = @At("RETURN"), method = "getStateForPlacement", cancellable = true)
     protected void getStateForPlacementProxy(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-        if (cir.getReturnValue() != null) {
-            cir.setReturnValue(cir.getReturnValue().setValue(CampfireBlock.LIT, false));
-            cir.setReturnValue(cir.getReturnValue().setValue(ICampfireBlockMixin.INFINITE, false));
-            cir.setReturnValue(cir.getReturnValue().setValue(ICampfireBlockMixin.RUNS_OUT, false));
-            cir.cancel();
-        }
+    if (cir.getReturnValue() != null) {
+
+        BlockState state = cir.getReturnValue();
+        boolean isGenerated = context.getPlayer() == null; // If there's no player, it's generated
+        // Gets state of campfire block, checking to see if it is generated or placed by the player
+        state = state.setValue(CampfireBlock.LIT, false)
+                    .setValue(ICampfireBlockMixin.INFINITE, isGenerated)
+                    .setValue(ICampfireBlockMixin.RUNS_OUT, false);
+        cir.setReturnValue(state);
+        cir.cancel();
+    }
     }
 
     @Inject(at = @At("RETURN"), method = "use", cancellable = true)


### PR DESCRIPTION
Added a config option that allows generated campfires to ignore rain when set to true. This is helpful when using campfires for decoration, and especially when generated structures use them for that purpose (villages with campfire chimneys will not have them extinguished now).